### PR TITLE
allow for multiple swagger versions per controller

### DIFF
--- a/src/Swagger/Attributes/ExcludeFromSwaggerAttribute.cs
+++ b/src/Swagger/Attributes/ExcludeFromSwaggerAttribute.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace Hein.Swagger.Attributes
 {
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
     public class ExcludeFromSwaggerAttribute : ApiExplorerSettingsAttribute
     {
         public ExcludeFromSwaggerAttribute() : base()

--- a/src/Swagger/Attributes/IgnoreSwaggerAttribute.cs
+++ b/src/Swagger/Attributes/IgnoreSwaggerAttribute.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace Hein.Swagger.Attributes
 {
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
     public class IgnoreSwaggerAttribute : ApiExplorerSettingsAttribute
     {
         public IgnoreSwaggerAttribute() : base()

--- a/src/Swagger/Attributes/SwaggerAttribute.cs
+++ b/src/Swagger/Attributes/SwaggerAttribute.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace Hein.Swagger.Attributes
 {
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
     public class SwaggerAttribute : ApiExplorerSettingsAttribute
     {
         public SwaggerAttribute() : base()

--- a/src/Swagger/Attributes/SwaggerControllerAttribute.cs
+++ b/src/Swagger/Attributes/SwaggerControllerAttribute.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using System;
+﻿using System;
 
 namespace Hein.Swagger.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class SwaggerControllerAttribute : SwaggerTagAttribute
     {
         public SwaggerControllerAttribute(string groupName) : base(groupName)

--- a/src/Swagger/Attributes/SwaggerDescriptionAttribute.cs
+++ b/src/Swagger/Attributes/SwaggerDescriptionAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Hein.Swagger.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
     public class SwaggerDescriptionAttribute : Attribute
     {
         public SwaggerDescriptionAttribute(string description)
@@ -13,6 +13,7 @@ namespace Hein.Swagger.Attributes
         public string Description { get; }
     }
 
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
     public class DescriptionAttribute : SwaggerDescriptionAttribute
     {
         public DescriptionAttribute(string description) : base(description)

--- a/src/Swagger/Attributes/SwaggerSummaryAttribute.cs
+++ b/src/Swagger/Attributes/SwaggerSummaryAttribute.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Hein.Swagger.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class SwaggerSummaryAttribute : Attribute
     {
         public SwaggerSummaryAttribute(string summary)
@@ -15,6 +13,7 @@ namespace Hein.Swagger.Attributes
         public string Summary { get; }
     }
 
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class SummaryAttribute : SwaggerSummaryAttribute
     {
         public SummaryAttribute(string summary) : base(summary)

--- a/src/Swagger/Filters/SwaggerSecurityDocumentFilter.cs
+++ b/src/Swagger/Filters/SwaggerSecurityDocumentFilter.cs
@@ -20,7 +20,7 @@ namespace Hein.Swagger.Filters
                 swaggerDoc.SecurityDefinitions = new Dictionary<string, SecurityScheme>();
             }
 
-            swaggerDoc.SecurityDefinitions.Add(_scheme.Name, _scheme);
+            swaggerDoc.SecurityDefinitions.Add(_scheme.Name.Replace("-", ""), _scheme);
 
             if (swaggerDoc.Security == null)
             {
@@ -29,7 +29,7 @@ namespace Hein.Swagger.Filters
 
             var securities = new List<IDictionary<string, IEnumerable<string>>>();
             var enforcer = new Dictionary<string, IEnumerable<string>>();
-            enforcer.Add(_scheme.Name, new List<string>());
+            enforcer.Add(_scheme.Name.Replace("-", ""), new List<string>());
             securities.Add(enforcer);
             foreach (var security in securities)
             {

--- a/src/Swagger/Filters/SwaggerUniqueOperationIdFilter.cs
+++ b/src/Swagger/Filters/SwaggerUniqueOperationIdFilter.cs
@@ -1,0 +1,14 @@
+﻿using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+
+namespace Hein.Swagger.Filters
+{
+    public class SwaggerUniqueOperationIdFilter : IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            operation.OperationId = Guid.NewGuid().ToString();
+        }
+    }
+}

--- a/src/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Swagger/SwaggerGenOptionsExtensions.cs
@@ -95,12 +95,21 @@ namespace Hein.Swagger
 
             options.DocInclusionPredicate((version, desc) =>
             {
-                var versions = desc.ControllerAttributes()
-                    .OfType<SwaggerVersionAttribute>()
-                    .SelectMany(attr => attr.Version)
-                    .ToArray();
+                var versionsAttrs = desc.ControllerAttributes()
+                    .OfType<SwaggerVersionAttribute>();
 
-                return new string(versions) == version;
+                if (versionsAttrs != null && versionsAttrs.Any())
+                {
+                    foreach (var versionAttr in versionsAttrs)
+                    {
+                        if (versionAttr.Version.Equals(version, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
             });
         }
     }

--- a/src/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Swagger/SwaggerGenOptionsExtensions.cs
@@ -13,6 +13,7 @@ namespace Hein.Swagger
     {
         public static void EnforceQueryKey(this SwaggerGenOptions options, string queryName, string description = null)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             var scheme = new QueryStringSecurityScheme(queryName, description);
             options.DocumentFilter<SwaggerSecurityDocumentFilter>(scheme);
             options.OperationFilter<SwaggerSecurityOperationalFilter>(scheme);
@@ -20,6 +21,7 @@ namespace Hein.Swagger
 
         public static void EnforceHeaderKey(this SwaggerGenOptions options, string headerName, string description = null)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             var scheme = new HeaderSecurityScheme(headerName, description);
             options.DocumentFilter<SwaggerSecurityDocumentFilter>(scheme);
             options.OperationFilter<SwaggerSecurityOperationalFilter>(scheme);
@@ -27,6 +29,7 @@ namespace Hein.Swagger
 
         public static void EnforceCookieKey(this SwaggerGenOptions options, string cookieName, string description = null)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             var scheme = new CookieSecurityScheme(cookieName, description);
             options.DocumentFilter<SwaggerSecurityDocumentFilter>(scheme);
             options.OperationFilter<SwaggerSecurityOperationalFilter>(scheme);
@@ -34,11 +37,13 @@ namespace Hein.Swagger
 
         public static void AddGithubRepository(this SwaggerGenOptions options, string githubRepositoryUrl)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.DocumentFilter<GithubRepositoryDocumentFilter>(githubRepositoryUrl);
         }
 
         public static void DescribeStatusCodes(this SwaggerGenOptions options, params HttpStatusCode[] codes)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.OperationFilter<SwaggerStatusCodeResponses>(codes);
         }
 
@@ -49,22 +54,26 @@ namespace Hein.Swagger
 
         public static void DescribeAllStatusCodes(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             var values = Enum.GetValues(typeof(HttpStatusCode)).Cast<HttpStatusCode>();
             DescribeStatusCodes(options, values.ToArray());
         }
 
         public static void DescribeRateLimitHeaders(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.OperationFilter<SwaggerRateLimitHeaders>();
         }
 
         public static void EnableControllerTags(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.OperationFilter<SwaggerControllerGroupTagOperationalFilter>();
         }
 
         public static void EnableDescriptionTags(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.OperationFilter<SwaggerDescriptionFilter>();
 
             //TODO ISSUE/FEATURE #1
@@ -73,16 +82,19 @@ namespace Hein.Swagger
 
         public static void EnableProducesHeaderTags(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.OperationFilter<SwaggerProducesHeadersFilter>();
         }
 
         public static void EnableSummaryTags(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             options.OperationFilter<SwaggerSummaryFilter>();
         }
 
         public static void EnableAnnotations(this SwaggerGenOptions options)
         {
+            options.OperationFilter<SwaggerUniqueOperationIdFilter>();
             EnableControllerTags(options);
             EnableDescriptionTags(options);
             EnableSummaryTags(options);


### PR DESCRIPTION
- attribute lock downs (to prevent dupes)
- unique operation ids for valid swaggers