### PR TITLE
Correctly enforce the security definition documented in swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <PackageReference Include="Hein.Swagger" Version="1.0.5" />
 
 <!-- if netcoreapp3.* use -->
-<PackageReference Include="Hein.Swagger" Version="2.0.0" />
+<PackageReference Include="Hein.Swagger" Version="2.0.1" />
 ```
 
 Fun Repo to create an easier 'Swagger Gen' for api documentation
@@ -19,13 +19,13 @@ I wanted to create some helper/extensions/add on's to the awesomeness of [Swagge
 So, I added some extension methods to add to the `SwaggerGenOptions` to achieve what 'I' think should be called.  I also added some Attributes/tags to add to your controllers, that will include/exclude from your swagger generation.
 
 ## IMPORTANT! Major Version Update
-1.0.5 => 2.0.0  
+1.0.5 => 2.0.1  
 With NetCore 3.1 being supported by AWS lambda now... I wanted to upgrade my apps to the new supported version.  By doing so everything I've created for this swagger helper is obsolete... so had to so a major overhaul renaming some classes to make interfaces work and so forth.  
 
 | Hein.Swagger | Swagger Versions | NetCore Versions |
 | --- | --- | --- |
 | 1.0.5 | Swagger V2 | netcoreapp2.* |
-| 2.0.0 | Swagger V3 | netcoreapp3.* |
+| 2.0.1 | Swagger V3 | netcoreapp3.* |
 
 # Cool Shiz!
 * [Adding a GitHub Repo Link](https://github.com/brandonhein/Hein.Swagger#add-github-repository-url)

--- a/sample/Swagger.Sample/Startup.cs
+++ b/sample/Swagger.Sample/Startup.cs
@@ -66,7 +66,7 @@ namespace Hein.Swagger.Sample
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseLegacySwagger();
+            app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "Hein.Swagger.Sample - v1");

--- a/src/Swagger/Filters/SwaggerSecurityDocumentFilter.cs
+++ b/src/Swagger/Filters/SwaggerSecurityDocumentFilter.cs
@@ -12,7 +12,6 @@ namespace Hein.Swagger.Filters
         public SwaggerSecurityDocumentFilter(SecuritySchemeBase scheme)
         {
             _scheme = scheme;
-            _scheme.Name = _scheme.Name.Replace("-", "");
         }
 
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
@@ -21,7 +20,7 @@ namespace Hein.Swagger.Filters
 
             var requirement = new OpenApiSecurityRequirement()
             {
-                [_scheme] = new List<string>() { _scheme.Name.Replace("-", "") }
+                [_scheme] = new List<string>()
             };
 
             if (!swaggerDoc.SecurityRequirements.Any(x => x.Equals(requirement)))
@@ -33,14 +32,15 @@ namespace Hein.Swagger.Filters
             {
                 swaggerDoc.Components = new OpenApiComponents();
             }
+
             if (swaggerDoc.Components.SecuritySchemes == null)
             {
                 swaggerDoc.Components.SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>();
             }
 
-            if (!swaggerDoc.Components.SecuritySchemes.ContainsKey(_scheme.Name.Replace("-", "")))
+            if (!swaggerDoc.Components.SecuritySchemes.ContainsKey(_scheme.Name))
             {
-                swaggerDoc.Components.SecuritySchemes.Add(_scheme.Name.Replace("-", ""), _scheme);
+                swaggerDoc.Components.SecuritySchemes.Add(_scheme.Name, _scheme);
             }
         }
     }

--- a/src/Swagger/Filters/SwaggerSecurityOperationalFilter.cs
+++ b/src/Swagger/Filters/SwaggerSecurityOperationalFilter.cs
@@ -18,12 +18,6 @@ namespace Hein.Swagger.Filters
         {
             operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
             operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
-
-            //var security = new List<Dictionary<string, IEnumerable<string>>>();
-            //security.Add(new Dictionary<string, IEnumerable<string>>()
-            //{
-            //    { _scheme.Type, new List<string>() }
-            //});
         }
     }
 }

--- a/src/Swagger/Security/Keys/ApiKeySchemeBase.cs
+++ b/src/Swagger/Security/Keys/ApiKeySchemeBase.cs
@@ -6,11 +6,14 @@ namespace Hein.Swagger.Security.Keys
     {
         protected ApiKeySchemeBase(string name, string description = null)
         {
+            base.Reference = new OpenApiReference()
+            {
+                Type = ReferenceType.SecurityScheme,
+                Id = name
+            };
             base.Name = name;
             base.Description = description;
             base.Type = SecuritySchemeType.ApiKey;
         }
-
-        public ParameterLocation In { get; set; }
     }
 }

--- a/src/Swagger/Security/Keys/CookieSecurityScheme.cs
+++ b/src/Swagger/Security/Keys/CookieSecurityScheme.cs
@@ -4,7 +4,7 @@
     {
         public CookieSecurityScheme(string name, string description = null) : base(name, description)
         {
-            In = Microsoft.OpenApi.Models.ParameterLocation.Cookie;
+            base.In = Microsoft.OpenApi.Models.ParameterLocation.Cookie;
         }
     }
 }

--- a/src/Swagger/Security/SecuritySchemeBase.cs
+++ b/src/Swagger/Security/SecuritySchemeBase.cs
@@ -4,6 +4,6 @@ namespace Hein.Swagger.Security
 {
     public abstract class SecuritySchemeBase : OpenApiSecurityScheme
     {
-        
+
     }
 }

--- a/src/Swagger/Swagger.csproj
+++ b/src/Swagger/Swagger.csproj
@@ -9,7 +9,7 @@
     <Description>Custom Swashbuckle.AspNetCore.SwaggerGen extensions</Description>
     <RepositoryUrl>https://github.com/brandonhein/Hein.Swagger</RepositoryUrl>
     <PackageProjectUrl>https://github.com/brandonhein/Hein.Swagger</PackageProjectUrl>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Swagger/SwaggerGenOptionsExtensions.cs
@@ -2,8 +2,10 @@
 using Hein.Swagger.Filters;
 using Hein.Swagger.Security.Keys;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 
@@ -14,7 +16,7 @@ namespace Hein.Swagger
         public static void EnforceQueryKey(this SwaggerGenOptions options, string queryName, string description = null)
         {
             options.OperationFilter<SwaggerUniqueOperationIdFilter>();
-            var scheme = new QueryStringSecurityScheme(queryName, description);
+            var scheme = new QueryStringSecurityScheme(queryName.Replace("-", ""), description);
             options.DocumentFilter<SwaggerSecurityDocumentFilter>(scheme);
             options.OperationFilter<SwaggerSecurityOperationalFilter>(scheme);
         }
@@ -22,7 +24,7 @@ namespace Hein.Swagger
         public static void EnforceHeaderKey(this SwaggerGenOptions options, string headerName, string description = null)
         {
             options.OperationFilter<SwaggerUniqueOperationIdFilter>();
-            var scheme = new HeaderSecurityScheme(headerName, description);
+            var scheme = new HeaderSecurityScheme(headerName.Replace("-", ""), description);
             options.DocumentFilter<SwaggerSecurityDocumentFilter>(scheme);
             options.OperationFilter<SwaggerSecurityOperationalFilter>(scheme);
         }
@@ -30,7 +32,7 @@ namespace Hein.Swagger
         public static void EnforceCookieKey(this SwaggerGenOptions options, string cookieName, string description = null)
         {
             options.OperationFilter<SwaggerUniqueOperationIdFilter>();
-            var scheme = new CookieSecurityScheme(cookieName, description);
+            var scheme = new CookieSecurityScheme(cookieName.Replace("-", ""), description);
             options.DocumentFilter<SwaggerSecurityDocumentFilter>(scheme);
             options.OperationFilter<SwaggerSecurityOperationalFilter>(scheme);
         }


### PR DESCRIPTION
part of the magic of the `OpenApiDocument` leverages Scheme ids... inside
`OpenApiReference` you need to set a `ReferenceType` as well as an `Id`.

Every scheme needs to have this~